### PR TITLE
fix: update pinned Expo Go to 57.0.3 and dedupe drift issues

### DIFF
--- a/.github/workflows/expo-go-drift.yml
+++ b/.github/workflows/expo-go-drift.yml
@@ -36,21 +36,31 @@ jobs:
 
       - name: Prepare issue body
         if: steps.diff.outputs.changed == 'true'
+        env:
+          PINNED_URL: ${{ steps.pinned.outputs.url }}
+          LATEST_URL: ${{ steps.latest.outputs.url }}
         run: |
-          cat <<'EOF' > /tmp/expo-go-drift.md
+          cat <<EOF > /tmp/expo-go-drift.md
           The Expo Go Android URL differs from the pinned version in this repo.
 
-          - Pinned: `${{ steps.pinned.outputs.url }}`
-          - Latest: `${{ steps.latest.outputs.url }}`
+          - Pinned: \`${PINNED_URL}\`
+          - Latest: \`${LATEST_URL}\`
 
           Recommended action:
           1) Review the new release
-          2) Update `EXPO_GO_ANDROID_URL` in `src/expo/constants.ts`
+          2) Update \`EXPO_GO_ANDROID_URL\` in \`src/expo/constants.ts\`
           EOF
 
-      - name: Create issue
+      - name: Create or update issue
         if: steps.diff.outputs.changed == 'true'
-        uses: peter-evans/create-issue-from-file@v5
-        with:
-          title: "Expo Go Android drift detected"
-          content-filepath: /tmp/expo-go-drift.md
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          title="Expo Go Android drift detected"
+          existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open \
+            --search "\"$title\" in:title" --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" --body-file /tmp/expo-go-drift.md
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" --title "$title" --body-file /tmp/expo-go-drift.md
+          fi

--- a/src/expo/constants.ts
+++ b/src/expo/constants.ts
@@ -1,4 +1,4 @@
 export const EXPO_GO_ANDROID_URL =
-  "https://github.com/expo/expo-go-releases/releases/download/Expo-Go-54.0.6/Expo-Go-54.0.6.apk";
+  "https://github.com/expo/expo-go-releases/releases/download/Expo-Go-57.0.3/Expo-Go-57.0.3.apk";
 
 export const EXPO_GO_VERSIONS_API = "https://exp.host/--/api/v2/versions/latest";


### PR DESCRIPTION
## Summary
- Updates `EXPO_GO_ANDROID_URL` from Expo-Go-54.0.6 to Expo-Go-57.0.3 (current `androidClientUrl` reported by https://exp.host/--/api/v2/versions/latest)
- Fixes the Expo Go Drift workflow to comment on an existing open drift issue instead of creating a duplicate every week
- Hardens the issue-body step by passing step outputs through `env` instead of inline interpolation

Closes #5, closes #6, closes #7, closes #8, closes #9, closes #10, closes #11, closes #12, closes #13