### PR TITLE
ci: pass drift step outputs through env to avoid shell interpolation

### DIFF
--- a/.github/workflows/expo-go-drift.yml
+++ b/.github/workflows/expo-go-drift.yml
@@ -27,8 +27,11 @@ jobs:
 
       - name: Compare URLs
         id: diff
+        env:
+          PINNED_URL: ${{ steps.pinned.outputs.url }}
+          LATEST_URL: ${{ steps.latest.outputs.url }}
         run: |
-          if [ "${{ steps.pinned.outputs.url }}" = "${{ steps.latest.outputs.url }}" ]; then
+          if [ "$PINNED_URL" = "$LATEST_URL" ]; then
             echo "changed=false" >> $GITHUB_OUTPUT
           else
             echo "changed=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Hardens the Expo Go Drift workflow: step outputs (including the URL fetched from the external exp.host API) are now passed to the compare step via `env` instead of inline `${{ }}` interpolation in the `run:` script, closing a potential command-injection vector flagged by security review.