### PR TITLE
ci: publish to npm via OIDC trusted publisher

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
           cache: npm
 
@@ -30,10 +30,13 @@ jobs:
       - name: Build
         run: npm run build
 
+      # npm >= 11.5.1 publishes via the OIDC trusted publisher configured on
+      # npmjs.com (no token) and attaches provenance automatically.
+      - name: Ensure npm with OIDC support
+        run: npm install -g npm@latest
+
       - name: Publish
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Sync server.json version
         run: |


### PR DESCRIPTION
The trusted publisher (frndchagas/expo-android · publish.yml) is configured
on npmjs.com, so npm >= 11.5.1 mints short-lived credentials via OIDC and
attaches provenance automatically — no NPM_TOKEN secret involved. The
existing token secret stays untouched as an emergency fallback until it
expires on Nov 3.
