### PR TITLE
ci: pin npm version in the publish pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
       # npm >= 11.5.1 publishes via the OIDC trusted publisher configured on
       # npmjs.com (no token) and attaches provenance automatically.
       - name: Ensure npm with OIDC support
-        run: npm install -g npm@latest
+        run: npm install -g npm@12.0.2
 
       - name: Publish
         run: npm publish --access public


### PR DESCRIPTION
npm@latest at publish time is a floating supply-chain dependency; pins
npm@12.0.2 — bump deliberately when upgrading.
