### PR TITLE
feat: add installExpoGo tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ npm test
 
 ## Tools
 
-Tools are exposed under your MCP server name. Example: `expo-android.tap`.
+Tool names are plain identifiers (e.g. `tap`); your MCP client prefixes them with the server name you registered.
 
 - `devices` — list connected devices and emulators.
 - `doctor` — validate adb availability and show connected devices.
@@ -140,6 +140,7 @@ Tools are exposed under your MCP server name. Example: `expo-android.tap`.
 - `keyEvent` — send Android key events (e.g., BACK, HOME).
 - `openApp` — launch an app by package name.
 - `listPackages` — list installed package names.
+- `installExpoGo` — download the pinned Expo Go APK and install it via `adb install -r` (pass `url` to install a different release).
 
 ## Search criteria
 

--- a/src/tools/android.ts
+++ b/src/tools/android.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { writeFile } from 'node:fs/promises';
+import { rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -15,6 +15,7 @@ import {
   setAdbSerialOverride,
 } from '../adb.js';
 import { ADB_PATH, ADB_PATH_SOURCE } from '../config.js';
+import { EXPO_GO_ANDROID_URL } from '../expo/constants.js';
 import {
   findElements,
   generateSummary,
@@ -1004,6 +1005,55 @@ export function registerAndroidTools(server: McpServer) {
         ? packages.filter((name) => name.includes(filter))
         : packages;
       return list('Packages fetched.', items);
+    }
+  );
+
+  server.registerTool(
+    'installExpoGo',
+    {
+      title: 'Install Expo Go',
+      description:
+        'Download the pinned Expo Go APK and install it on the device via adb install -r. Pass url to install a different release.',
+      inputSchema: withSerial(
+        z.object({
+          url: z
+            .string()
+            .url()
+            .optional()
+            .describe('APK URL override (defaults to the pinned Expo Go release)'),
+        })
+      ),
+    },
+    async ({ url, serial }: { url?: string; serial?: string }) => {
+      const apkUrl = url ?? EXPO_GO_ANDROID_URL;
+      const response = await fetch(apkUrl);
+      if (!response.ok) {
+        throw new Error(
+          `Failed to download Expo Go APK (HTTP ${response.status}) from ${apkUrl}`
+        );
+      }
+      const apkBytes = Buffer.from(await response.arrayBuffer());
+      const apkPath = join(tmpdir(), `expo-go-${randomUUID()}.apk`);
+      await writeFile(apkPath, apkBytes);
+      try {
+        const { stdout } = await adbExec(['install', '-r', apkPath], {
+          serial: normalizeSerial(serial),
+          // large APK: adb install can far exceed the default command timeout
+          timeout: 300_000,
+        });
+        const output = toText(stdout).trim();
+        if (!/Success/i.test(output)) {
+          throw new Error(`adb install did not report success: ${output}`);
+        }
+        const sizeMb = (apkBytes.length / 1048576).toFixed(1);
+        return ok(`Expo Go installed (${sizeMb} MB APK).`, {
+          url: apkUrl,
+          sizeBytes: apkBytes.length,
+          output,
+        });
+      } finally {
+        await rm(apkPath, { force: true });
+      }
     }
   );
 }


### PR DESCRIPTION
Downloads the pinned Expo Go APK (EXPO_GO_ANDROID_URL — previously unused
by any runtime code despite being watched by the drift workflow) and
installs it on the selected device via adb install -r, with a 5-minute
timeout for the large APK and temp-file cleanup. Pass url to install a
different release. Also fixes the README's misleading dotted tool-name
example.
