### PR TITLE
feat: ship an MCPB bundle and report coverage in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,6 @@ jobs:
         run: npm run build
       - name: Test
         run: npm test
+      - name: Coverage
+        if: matrix.node == 22
+        run: npm run test:coverage

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,8 +12,50 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  # Releases are created with GITHUB_TOKEN, which never fires the `release`
+  # event for other workflows — so the MCPB bundle is chained here instead.
+  mcpb-bundle:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Stamp manifest version from release tag
+        env:
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+        run: |
+          version="${TAG#expo-android-v}"
+          node -e "const fs=require('fs');const m=JSON.parse(fs.readFileSync('manifest.json','utf8'));m.version=process.argv[1];fs.writeFileSync('manifest.json', JSON.stringify(m,null,2)+'\n');" "$version"
+
+      - name: Prune to production dependencies
+        run: npm prune --omit=dev
+
+      - name: Pack bundle
+        run: npx --yes @anthropic-ai/mcpb@2.1.2 pack . expo-android.mcpb
+
+      - name: Upload to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+        run: gh release upload "$TAG" expo-android.mcpb --clobber

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ adb devices
 
 ## Install
 
+**Claude Desktop, one-click:** download [`expo-android.mcpb`](https://github.com/frndchagas/expo-android/releases/latest/download/expo-android.mcpb) from the latest release and drag it into **Settings → Extensions**. You can leave both fields empty — adb is auto-detected and the only connected device is used by default.
+
+**Via npm:**
+
 ```bash
 npm install -g @fndchagas/expo-android
 # or

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,44 @@
+{
+  "manifest_version": "0.2",
+  "name": "expo-android",
+  "display_name": "Expo Android",
+  "version": "0.0.0",
+  "description": "Drive an Android emulator or device over ADB: inspect the UI, tap elements by text, assert state, and install Expo Go.",
+  "author": {
+    "name": "Fernando Chagas",
+    "url": "https://github.com/frndchagas"
+  },
+  "homepage": "https://github.com/frndchagas/expo-android",
+  "license": "MIT",
+  "server": {
+    "type": "node",
+    "entry_point": "dist/server.js",
+    "mcp_config": {
+      "command": "node",
+      "args": ["${__dirname}/dist/server.js"],
+      "env": {
+        "ADB_PATH": "${user_config.adb_path}",
+        "ADB_SERIAL": "${user_config.adb_serial}"
+      }
+    }
+  },
+  "user_config": {
+    "adb_path": {
+      "type": "string",
+      "title": "ADB path",
+      "description": "Path to the adb binary. Leave empty to auto-detect from PATH, ANDROID_HOME, or ANDROID_SDK_ROOT.",
+      "required": false
+    },
+    "adb_serial": {
+      "type": "string",
+      "title": "Device serial",
+      "description": "Device or emulator serial to target. Leave empty to use the only connected device.",
+      "required": false
+    }
+  },
+  "compatibility": {
+    "runtimes": {
+      "node": ">=18"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start": "node dist/server.js",
     "test": "node --test",
     "prepublishOnly": "npm run build",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test:coverage": "node --test --experimental-test-coverage"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.25.1",


### PR DESCRIPTION
Adds manifest.json plus a bundle job chained into release-please (the
release event never fires for GITHUB_TOKEN-created releases), so every
release carries expo-android.mcpb for one-click Claude Desktop install.
Both user config fields are optional: adb is auto-detected and the only
connected device is used by default.

CI now also reports coverage via node --test --experimental-test-coverage
on Node 22.
