### PR TITLE
fix: start the server without adb and report it per tool call

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ Serial selection priority:
 
 ### adb not found (spawn adb ENOENT)
 
-If you see an error like `ADB executable not found` or `spawn adb ENOENT`, set `ADB_PATH`
+The server starts even when adb is missing — tools return the `ADB executable not found`
+error until adb becomes reachable (run `doctor` to diagnose). To fix it, set `ADB_PATH`
 or export an SDK path:
 
 ```bash

--- a/src/adb.ts
+++ b/src/adb.ts
@@ -83,11 +83,18 @@ async function assertSerialAvailable(serial: string) {
 
 async function adbExecRaw(args: string[], options: ExecOptions = {}) {
   const { serial: _serial, ...execOptions } = options;
-  return execFileAsync(ADB_PATH, args, {
-    timeout: ADB_TIMEOUT_MS,
-    maxBuffer: ADB_MAX_BUFFER,
-    ...execOptions,
-  });
+  try {
+    return await execFileAsync(ADB_PATH, args, {
+      timeout: ADB_TIMEOUT_MS,
+      maxBuffer: ADB_MAX_BUFFER,
+      ...execOptions,
+    });
+  } catch (error) {
+    if (isAdbSpawnError(error)) {
+      throw new Error(formatAdbNotFoundMessage(error), { cause: error });
+    }
+    throw error;
+  }
 }
 
 export async function adbExec(args: string[], options: ExecOptions = {}) {
@@ -215,6 +222,17 @@ export async function getAdbVersion() {
   return toText(stdout).trim();
 }
 
+const ADB_SPAWN_ERROR_CODES = new Set(['ENOENT', 'EACCES', 'ENOTDIR']);
+
+function isAdbSpawnError(error: unknown) {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    ADB_SPAWN_ERROR_CODES.has(String((error as { code?: unknown }).code))
+  );
+}
+
 function formatAdbNotFoundMessage(error: unknown) {
   const errorCode =
     typeof error === 'object' && error !== null && 'code' in error
@@ -234,11 +252,7 @@ function formatAdbNotFoundMessage(error: unknown) {
 }
 
 export async function assertAdbAvailable() {
-  try {
-    await adbExecRaw(['version'], { serial: null });
-  } catch (error) {
-    throw new Error(formatAdbNotFoundMessage(error), { cause: error });
-  }
+  await adbExecRaw(['version'], { serial: null });
 }
 
 export async function getAdbSerialState({ strict = false } = {}) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,12 +18,18 @@ const server = new McpServer({
 
 registerAndroidTools(server);
 
+// The server must start even without adb (MCP directories run it in bare
+// containers to validate the handshake), so a missing adb is reported per
+// tool call instead of aborting here.
 async function warmUpAdb() {
   try {
     await assertAdbAvailable();
   } catch (error) {
     console.error(error instanceof Error ? error.message : String(error));
-    process.exit(1);
+    console.error(
+      '[expo-android] adb is unavailable; starting anyway. Tools will report this error until adb is reachable (run doctor to diagnose).'
+    );
+    return;
   }
 
   try {

--- a/tests/server-startup.test.js
+++ b/tests/server-startup.test.js
@@ -1,0 +1,53 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const serverPath = join(__dirname, '..', 'dist', 'server.js');
+
+function connectWithoutAdb() {
+  return new StdioClientTransport({
+    command: process.execPath,
+    args: [serverPath],
+    env: {
+      ...process.env,
+      ADB_PATH: '/nonexistent/adb',
+      MCP_TRANSPORT: 'stdio',
+    },
+  });
+}
+
+test('server completes the MCP handshake when adb is missing', async () => {
+  const client = new Client({ name: 'smoke-test', version: '0.0.0' });
+  await client.connect(connectWithoutAdb());
+
+  try {
+    const { tools } = await client.listTools();
+    assert.ok(tools.some((tool) => tool.name === 'devices'));
+  } finally {
+    await client.close();
+  }
+});
+
+test('tools report the adb-not-found error instead of crashing', async () => {
+  const client = new Client({ name: 'smoke-test', version: '0.0.0' });
+  await client.connect(connectWithoutAdb());
+
+  try {
+    const result = await client.callTool({ name: 'devices', arguments: {} });
+    assert.equal(result.isError, true);
+    const text = result.content
+      .map((item) => (item.type === 'text' ? item.text : ''))
+      .join('\n');
+    assert.match(text, /ADB executable not found/);
+    assert.match(text, /ADB_PATH/);
+
+    const doctor = await client.callTool({ name: 'doctor', arguments: {} });
+    assert.notEqual(doctor.isError, true);
+  } finally {
+    await client.close();
+  }
+});


### PR DESCRIPTION
## Problema

Os builds do Glama falham em 100% dos testes: o container compila, mas o servidor faz `process.exit(1)` no startup porque não encontra o `adb` — e sai antes de responder ao ping MCP (`Container exited with code 1 before responding to ping`). Diretórios MCP validam servidores em containers genéricos, sem Android SDK.

## Correção

Detecção de adb passa a ser lazy:

- **`src/server.ts`** — `warmUpAdb` não aborta mais o processo; loga o erro + aviso em stderr e segue com o handshake.
- **`src/adb.ts`** — erros de spawn (`ENOENT`/`EACCES`/`ENOTDIR`) em `adbExecRaw` são traduzidos para a mensagem completa de "ADB executable not found" com instruções de fix, então qualquer tool que precise de adb devolve essa orientação como tool error (o SDK converte a exceção em `isError: true`). `assertAdbAvailable` deixa de embrulhar o erro duas vezes.
- **`tests/server-startup.test.js`** — smoke tests via client do SDK com `ADB_PATH` inválido: handshake + `tools/list` funcionam, `devices` devolve o erro amigável como resultado, `doctor` responde sem erro.
- **README** — documenta que o servidor inicia sem adb.

## Test plan

- [x] `npm run lint` limpo
- [x] `npm run build` limpo
- [x] `npm test` — 11/11 (2 novos smoke tests)
- [ ] Após merge: Sync Server + Build no Glama admin deve passar